### PR TITLE
Wave 2: Educator/parent profile schemas and linking hooks

### DIFF
--- a/src/hooks/useClassManagement.ts
+++ b/src/hooks/useClassManagement.ts
@@ -1,0 +1,129 @@
+import { useEffect, useState, useCallback } from 'react'
+import { supabase } from '../../utils/supabase/client'
+import { useAuthStore } from '../store/authStore'
+import type { ClassRecord, ClassEnrollment } from '../types/educator'
+
+export function useClassManagement() {
+  const user = useAuthStore((s) => s.user)
+  const [classes, setClasses] = useState<ClassRecord[]>([])
+  const [loading, setLoading] = useState(true)
+  const [error, setError] = useState<string | null>(null)
+
+  const fetchClasses = useCallback(async () => {
+    if (!user?.id) {
+      setLoading(false)
+      return
+    }
+
+    setLoading(true)
+    setError(null)
+    try {
+      const { data, error: err } = await supabase
+        .from('classes')
+        .select('*')
+        .eq('educator_id', user.id)
+        .order('created_at', { ascending: false })
+
+      if (err) throw err
+      setClasses((data as ClassRecord[]) ?? [])
+    } catch (e) {
+      setError(e instanceof Error ? e.message : 'Failed to load classes')
+    } finally {
+      setLoading(false)
+    }
+  }, [user?.id])
+
+  useEffect(() => {
+    fetchClasses()
+  }, [fetchClasses])
+
+  const createClass = useCallback(
+    async (name: string, description?: string) => {
+      if (!user?.id) return
+
+      const { error: err } = await supabase
+        .from('classes')
+        .insert({ educator_id: user.id, name, description: description ?? null })
+
+      if (err) throw err
+      await fetchClasses()
+    },
+    [user?.id, fetchClasses],
+  )
+
+  const updateClass = useCallback(
+    async (classId: string, updates: { name?: string; description?: string }) => {
+      const { error: err } = await supabase
+        .from('classes')
+        .update({ ...updates, updated_at: new Date().toISOString() })
+        .eq('id', classId)
+
+      if (err) throw err
+      await fetchClasses()
+    },
+    [fetchClasses],
+  )
+
+  const deleteClass = useCallback(
+    async (classId: string) => {
+      const { error: err } = await supabase
+        .from('classes')
+        .delete()
+        .eq('id', classId)
+
+      if (err) throw err
+      await fetchClasses()
+    },
+    [fetchClasses],
+  )
+
+  const enrollStudent = useCallback(
+    async (classId: string, studentId: string) => {
+      const { error: err } = await supabase
+        .from('class_enrollments')
+        .insert({ class_id: classId, student_id: studentId })
+
+      if (err) throw err
+    },
+    [],
+  )
+
+  const unenrollStudent = useCallback(
+    async (classId: string, studentId: string) => {
+      const { error: err } = await supabase
+        .from('class_enrollments')
+        .delete()
+        .eq('class_id', classId)
+        .eq('student_id', studentId)
+
+      if (err) throw err
+    },
+    [],
+  )
+
+  const getClassEnrollments = useCallback(
+    async (classId: string): Promise<ClassEnrollment[]> => {
+      const { data, error: err } = await supabase
+        .from('class_enrollments')
+        .select('*')
+        .eq('class_id', classId)
+
+      if (err) throw err
+      return (data as ClassEnrollment[]) ?? []
+    },
+    [],
+  )
+
+  return {
+    classes,
+    loading,
+    error,
+    createClass,
+    updateClass,
+    deleteClass,
+    enrollStudent,
+    unenrollStudent,
+    getClassEnrollments,
+    refetch: fetchClasses,
+  }
+}

--- a/src/hooks/useEducatorProfile.ts
+++ b/src/hooks/useEducatorProfile.ts
@@ -1,0 +1,59 @@
+import { useEffect, useState, useCallback } from 'react'
+import { supabase } from '../../utils/supabase/client'
+import { useAuthStore } from '../store/authStore'
+import type { EducatorProfile } from '../types/educator'
+
+export function useEducatorProfile() {
+  const user = useAuthStore((s) => s.user)
+  const [profile, setProfile] = useState<EducatorProfile | null>(null)
+  const [loading, setLoading] = useState(true)
+  const [error, setError] = useState<string | null>(null)
+
+  const fetchProfile = useCallback(async () => {
+    if (!user?.id) {
+      setLoading(false)
+      return
+    }
+
+    setLoading(true)
+    setError(null)
+    try {
+      const { data, error: err } = await supabase
+        .from('educator_profiles')
+        .select('*')
+        .eq('user_id', user.id)
+        .single()
+
+      if (err && err.code !== 'PGRST116') throw err
+      setProfile(data as EducatorProfile | null)
+    } catch (e) {
+      setError(e instanceof Error ? e.message : 'Failed to load educator profile')
+    } finally {
+      setLoading(false)
+    }
+  }, [user?.id])
+
+  useEffect(() => {
+    fetchProfile()
+  }, [fetchProfile])
+
+  const upsertProfile = useCallback(
+    async (updates: Partial<Omit<EducatorProfile, 'user_id' | 'created_at' | 'updated_at'>>) => {
+      if (!user?.id) return
+
+      const { error: err } = await supabase
+        .from('educator_profiles')
+        .upsert({
+          user_id: user.id,
+          ...updates,
+          updated_at: new Date().toISOString(),
+        })
+
+      if (err) throw err
+      await fetchProfile()
+    },
+    [user?.id, fetchProfile],
+  )
+
+  return { profile, loading, error, upsertProfile, refetch: fetchProfile }
+}

--- a/src/hooks/useParentProfile.ts
+++ b/src/hooks/useParentProfile.ts
@@ -1,0 +1,59 @@
+import { useEffect, useState, useCallback } from 'react'
+import { supabase } from '../../utils/supabase/client'
+import { useAuthStore } from '../store/authStore'
+import type { ParentProfile } from '../types/parent'
+
+export function useParentProfile() {
+  const user = useAuthStore((s) => s.user)
+  const [profile, setProfile] = useState<ParentProfile | null>(null)
+  const [loading, setLoading] = useState(true)
+  const [error, setError] = useState<string | null>(null)
+
+  const fetchProfile = useCallback(async () => {
+    if (!user?.id) {
+      setLoading(false)
+      return
+    }
+
+    setLoading(true)
+    setError(null)
+    try {
+      const { data, error: err } = await supabase
+        .from('parent_profiles')
+        .select('*')
+        .eq('user_id', user.id)
+        .single()
+
+      if (err && err.code !== 'PGRST116') throw err
+      setProfile(data as ParentProfile | null)
+    } catch (e) {
+      setError(e instanceof Error ? e.message : 'Failed to load parent profile')
+    } finally {
+      setLoading(false)
+    }
+  }, [user?.id])
+
+  useEffect(() => {
+    fetchProfile()
+  }, [fetchProfile])
+
+  const upsertProfile = useCallback(
+    async (updates: Partial<Omit<ParentProfile, 'user_id' | 'created_at' | 'updated_at'>>) => {
+      if (!user?.id) return
+
+      const { error: err } = await supabase
+        .from('parent_profiles')
+        .upsert({
+          user_id: user.id,
+          ...updates,
+          updated_at: new Date().toISOString(),
+        })
+
+      if (err) throw err
+      await fetchProfile()
+    },
+    [user?.id, fetchProfile],
+  )
+
+  return { profile, loading, error, upsertProfile, refetch: fetchProfile }
+}

--- a/src/hooks/useParentStudentLinks.ts
+++ b/src/hooks/useParentStudentLinks.ts
@@ -1,0 +1,108 @@
+import { useEffect, useState, useCallback } from 'react'
+import { supabase } from '../../utils/supabase/client'
+import { useAuthStore } from '../store/authStore'
+import type { ParentStudentLink, LinkedStudent } from '../types/parent'
+
+export function useParentStudentLinks() {
+  const user = useAuthStore((s) => s.user)
+  const [links, setLinks] = useState<LinkedStudent[]>([])
+  const [loading, setLoading] = useState(true)
+  const [error, setError] = useState<string | null>(null)
+
+  const fetchLinks = useCallback(async () => {
+    if (!user?.id) {
+      setLoading(false)
+      return
+    }
+
+    setLoading(true)
+    setError(null)
+    try {
+      const { data, error: err } = await supabase
+        .from('parent_student_links')
+        .select(`
+          id, parent_id, student_id, status, created_at,
+          student:profiles!parent_student_links_student_id_fkey (
+            user_id, display_name, avatar_url, streak_days, lessons_completed
+          )
+        `)
+        .eq('parent_id', user.id)
+        .order('created_at', { ascending: false })
+
+      if (err) throw err
+
+      const linked: LinkedStudent[] = ((data as Record<string, unknown>[]) ?? []).map((row) => ({
+        link: {
+          id: row.id as string,
+          parent_id: row.parent_id as string,
+          student_id: row.student_id as string,
+          status: row.status as ParentStudentLink['status'],
+          created_at: row.created_at as string,
+        },
+        student: row.student as LinkedStudent['student'],
+      }))
+
+      setLinks(linked)
+    } catch (e) {
+      setError(e instanceof Error ? e.message : 'Failed to load linked students')
+    } finally {
+      setLoading(false)
+    }
+  }, [user?.id])
+
+  useEffect(() => {
+    fetchLinks()
+  }, [fetchLinks])
+
+  const linkStudent = useCallback(
+    async (studentId: string) => {
+      if (!user?.id) return
+
+      const { error: err } = await supabase
+        .from('parent_student_links')
+        .insert({ parent_id: user.id, student_id: studentId, status: 'pending' })
+
+      if (err) throw err
+      await fetchLinks()
+    },
+    [user?.id, fetchLinks],
+  )
+
+  const updateLinkStatus = useCallback(
+    async (linkId: string, status: 'active' | 'revoked') => {
+      const { error: err } = await supabase
+        .from('parent_student_links')
+        .update({ status })
+        .eq('id', linkId)
+
+      if (err) throw err
+      await fetchLinks()
+    },
+    [fetchLinks],
+  )
+
+  const unlinkStudent = useCallback(
+    async (linkId: string) => {
+      const { error: err } = await supabase
+        .from('parent_student_links')
+        .delete()
+        .eq('id', linkId)
+
+      if (err) throw err
+      await fetchLinks()
+    },
+    [fetchLinks],
+  )
+
+  return {
+    links,
+    activeLinks: links.filter((l) => l.link.status === 'active'),
+    pendingLinks: links.filter((l) => l.link.status === 'pending'),
+    loading,
+    error,
+    linkStudent,
+    updateLinkStatus,
+    unlinkStudent,
+    refetch: fetchLinks,
+  }
+}

--- a/src/types/educator.ts
+++ b/src/types/educator.ts
@@ -1,0 +1,35 @@
+export interface EducatorProfile {
+  user_id: string
+  school_name: string | null
+  department: string | null
+  subjects: string[]
+  certifications: string[]
+  bio: string | null
+  years_experience: number
+  max_class_size: number
+  accepting_students: boolean
+  created_at: string
+  updated_at: string
+}
+
+export interface ClassRecord {
+  id: string
+  educator_id: string
+  name: string
+  description: string | null
+  created_at: string
+  updated_at: string
+}
+
+export interface ClassEnrollment {
+  id: string
+  class_id: string
+  student_id: string
+  enrolled_at: string
+}
+
+export interface ClassWithStudents extends ClassRecord {
+  enrollments: (ClassEnrollment & {
+    student: { user_id: string; display_name: string; avatar_url: string | null }
+  })[]
+}

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -11,3 +11,17 @@ export type {
   ProgressStatus,
 } from './progress'
 export type { Database } from './database'
+export type {
+  EducatorProfile,
+  ClassRecord,
+  ClassEnrollment,
+  ClassWithStudents,
+} from './educator'
+export type {
+  ParentProfile,
+  ParentStudentLink,
+  LinkedStudent,
+  RelationshipType,
+  ContactPreference,
+  NotificationFrequency,
+} from './parent'

--- a/src/types/parent.ts
+++ b/src/types/parent.ts
@@ -1,0 +1,34 @@
+export type RelationshipType = 'parent' | 'guardian' | 'caregiver' | 'other'
+export type ContactPreference = 'email' | 'phone' | 'both' | 'none'
+export type NotificationFrequency = 'daily' | 'weekly' | 'monthly' | 'immediate'
+
+export interface ParentProfile {
+  user_id: string
+  relationship_type: RelationshipType
+  contact_phone: string | null
+  contact_preference: ContactPreference
+  notification_frequency: NotificationFrequency
+  timezone: string
+  max_linked_students: number
+  created_at: string
+  updated_at: string
+}
+
+export interface ParentStudentLink {
+  id: string
+  parent_id: string
+  student_id: string
+  status: 'pending' | 'active' | 'revoked'
+  created_at: string
+}
+
+export interface LinkedStudent {
+  link: ParentStudentLink
+  student: {
+    user_id: string
+    display_name: string
+    avatar_url: string | null
+    streak_days: number
+    lessons_completed: number
+  }
+}

--- a/supabase/migrations/008_educator_profiles.sql
+++ b/supabase/migrations/008_educator_profiles.sql
@@ -1,0 +1,74 @@
+-- Educator profile extension
+-- Adds educator-specific fields beyond the base profiles table.
+-- The base profiles.role = 'educator' gates access.
+
+create table if not exists public.educator_profiles (
+  user_id uuid primary key references public.profiles(user_id) on delete cascade,
+  school_name text,
+  department text,
+  subjects text[] default '{}',
+  certifications text[] default '{}',
+  bio text,
+  years_experience integer default 0 check (years_experience >= 0),
+  max_class_size integer default 30 check (max_class_size > 0),
+  accepting_students boolean default true,
+  created_at timestamptz default now(),
+  updated_at timestamptz default now()
+);
+
+-- Index for finding educators by subject
+create index if not exists idx_educator_profiles_subjects
+  on public.educator_profiles using gin (subjects);
+
+-- RLS
+alter table public.educator_profiles enable row level security;
+
+-- Educators can read/update their own profile
+create policy "Educators can view own profile"
+  on public.educator_profiles for select
+  using (auth.uid() = user_id);
+
+create policy "Educators can update own profile"
+  on public.educator_profiles for update
+  using (auth.uid() = user_id);
+
+create policy "Educators can insert own profile"
+  on public.educator_profiles for insert
+  with check (auth.uid() = user_id);
+
+-- Students can view their educator's profile (via class enrollment)
+create policy "Students can view their educators"
+  on public.educator_profiles for select
+  using (
+    exists (
+      select 1 from public.class_enrollments ce
+      join public.classes c on c.id = ce.class_id
+      where c.educator_id = educator_profiles.user_id
+        and ce.student_id = auth.uid()
+    )
+  );
+
+-- Parents can view educators of their linked students
+create policy "Parents can view child educators"
+  on public.educator_profiles for select
+  using (
+    exists (
+      select 1 from public.parent_student_links psl
+      join public.class_enrollments ce on ce.student_id = psl.student_id
+      join public.classes c on c.id = ce.class_id
+      where c.educator_id = educator_profiles.user_id
+        and psl.parent_id = auth.uid()
+        and psl.status = 'active'
+    )
+  );
+
+-- Admins can view all educator profiles
+create policy "Admins can view all educator profiles"
+  on public.educator_profiles for select
+  using (
+    exists (
+      select 1 from public.profiles
+      where profiles.user_id = auth.uid()
+        and profiles.role = 'admin'
+    )
+  );

--- a/supabase/migrations/009_parent_profiles.sql
+++ b/supabase/migrations/009_parent_profiles.sql
@@ -1,0 +1,56 @@
+-- Parent profile extension
+-- Adds parent-specific fields beyond the base profiles table.
+-- The base profiles.role = 'parent' gates access.
+
+create table if not exists public.parent_profiles (
+  user_id uuid primary key references public.profiles(user_id) on delete cascade,
+  relationship_type text check (relationship_type in ('parent', 'guardian', 'caregiver', 'other')) default 'parent',
+  contact_phone text,
+  contact_preference text check (contact_preference in ('email', 'phone', 'both', 'none')) default 'email',
+  notification_frequency text check (notification_frequency in ('daily', 'weekly', 'monthly', 'immediate')) default 'weekly',
+  timezone text default 'America/New_York',
+  max_linked_students integer default 5 check (max_linked_students > 0),
+  created_at timestamptz default now(),
+  updated_at timestamptz default now()
+);
+
+-- RLS
+alter table public.parent_profiles enable row level security;
+
+-- Parents can read/update their own profile
+create policy "Parents can view own profile"
+  on public.parent_profiles for select
+  using (auth.uid() = user_id);
+
+create policy "Parents can update own profile"
+  on public.parent_profiles for update
+  using (auth.uid() = user_id);
+
+create policy "Parents can insert own profile"
+  on public.parent_profiles for insert
+  with check (auth.uid() = user_id);
+
+-- Educators can view parent profiles of their students
+create policy "Educators can view student parents"
+  on public.parent_profiles for select
+  using (
+    exists (
+      select 1 from public.parent_student_links psl
+      join public.class_enrollments ce on ce.student_id = psl.student_id
+      join public.classes c on c.id = ce.class_id
+      where psl.parent_id = parent_profiles.user_id
+        and c.educator_id = auth.uid()
+        and psl.status = 'active'
+    )
+  );
+
+-- Admins can view all parent profiles
+create policy "Admins can view all parent profiles"
+  on public.parent_profiles for select
+  using (
+    exists (
+      select 1 from public.profiles
+      where profiles.user_id = auth.uid()
+        and profiles.role = 'admin'
+    )
+  );


### PR DESCRIPTION
## Summary
- Educator profile migration (008) with RLS policies for self, students, parents, admins
- Parent profile migration (009) with RLS policies for self, educators, admins
- TypeScript types for educator domain (EducatorProfile, ClassRecord, ClassEnrollment)
- TypeScript types for parent domain (ParentProfile, ParentStudentLink, LinkedStudent)
- `useEducatorProfile` hook — CRUD for educator-specific profile data
- `useParentProfile` hook — CRUD for parent-specific profile data
- `useClassManagement` hook — create/update/delete classes, enroll/unenroll students
- `useParentStudentLinks` hook — link/unlink students, manage pending/active/revoked status

## Issues Closed
Closes #49, #53, #66, #68

## Test plan
- [x] `npm run typecheck` — 0 errors
- [x] `npm run lint` — 0 warnings
- [x] `npm run test -- --run` — 24/24 passing
- [x] `npm run build` — clean production build

🤖 Generated with [Claude Code](https://claude.com/claude-code)