### PR TITLE
Harden RLS lifecycle policies and secure AI edge functions

### DIFF
--- a/src/components/parent/ParentMessages.tsx
+++ b/src/components/parent/ParentMessages.tsx
@@ -75,10 +75,10 @@ export function ParentMessages() {
     setError(null)
     try {
       const { data, error: err } = await supabase
-        .from('notifications')
-        .select('*')
+        .from('messages')
+        .select('id, sender_id, recipient_id, body, created_at')
         .or(
-          `and(user_id.eq.${user.id},type.eq.info),and(user_id.eq.${selectedEducatorId},type.eq.info)`,
+          `and(sender_id.eq.${user.id},recipient_id.eq.${selectedEducatorId}),and(sender_id.eq.${selectedEducatorId},recipient_id.eq.${user.id})`,
         )
         .order('created_at', { ascending: true })
         .limit(50)
@@ -86,13 +86,13 @@ export function ParentMessages() {
       if (err) throw err
 
       setMessages(
-        (data ?? []).map((n) => ({
-          id: n.id,
-          sender_id: n.user_id,
-          receiver_id: n.user_id === user.id ? selectedEducatorId : user.id,
-          content: n.body ?? '',
-          created_at: n.created_at,
-          sender_name: n.user_id === user.id ? 'You' : 'Educator',
+        (data ?? []).map((message) => ({
+          id: message.id,
+          sender_id: message.sender_id,
+          receiver_id: message.recipient_id,
+          content: message.body,
+          created_at: message.created_at,
+          sender_name: message.sender_id === user.id ? 'You' : 'Educator',
         })),
       )
     } catch (e) {
@@ -106,7 +106,7 @@ export function ParentMessages() {
     fetchMessages()
   }, [fetchMessages])
 
-  // Supabase Realtime — subscribe to new notifications for the selected educator thread
+  // Supabase Realtime — subscribe to new messages for the selected educator thread
   useEffect(() => {
     if (!user?.id || !selectedEducatorId) return
 
@@ -122,8 +122,8 @@ export function ParentMessages() {
         {
           event: 'INSERT',
           schema: 'public',
-          table: 'notifications',
-          filter: `user_id=eq.${user.id}`,
+          table: 'messages',
+          filter: `recipient_id=eq.${user.id}`,
         },
         () => {
           void fetchMessages()
@@ -143,11 +143,9 @@ export function ParentMessages() {
     if (!user?.id || !selectedEducatorId || !newMessage.trim()) return
     setError(null)
     try {
-      // Use notifications table as a simple messaging mechanism
-      const { error: err } = await supabase.from('notifications').insert({
-        user_id: selectedEducatorId,
-        type: 'info',
-        title: 'Message from parent',
+      const { error: err } = await supabase.from('messages').insert({
+        sender_id: user.id,
+        recipient_id: selectedEducatorId,
         body: newMessage.trim(),
       })
 

--- a/src/components/parent/ParentStudentList.tsx
+++ b/src/components/parent/ParentStudentList.tsx
@@ -9,7 +9,7 @@ import { Avatar } from '../ui/Avatar'
 import { useParentStudentLinks } from '../../hooks/useParentStudentLinks'
 
 export function ParentStudentList() {
-  const { links, loading, error, linkStudent, updateLinkStatus, unlinkStudent } = useParentStudentLinks()
+  const { links, loading, error, linkStudent, updateLinkStatus } = useParentStudentLinks()
   const [studentId, setStudentId] = useState('')
   const [actionError, setActionError] = useState<string | null>(null)
 
@@ -70,14 +70,11 @@ export function ParentStudentList() {
                       Approve
                     </Button>
                   )}
-                  {(link.status === 'active' || link.status === 'approved') && (
+                  {link.status === 'active' && (
                     <Button variant="ghost" onClick={() => updateLinkStatus(link.id, 'revoked')}>
                       Revoke
                     </Button>
                   )}
-                  <Button variant="ghost" onClick={() => unlinkStudent(link.id)}>
-                    Remove
-                  </Button>
                 </div>
               </div>
             </Card>

--- a/src/hooks/useParentStudentLinks.ts
+++ b/src/hooks/useParentStudentLinks.ts
@@ -69,23 +69,10 @@ export function useParentStudentLinks() {
   )
 
   const updateLinkStatus = useCallback(
-    async (linkId: string, status: 'active' | 'approved' | 'revoked' | 'rejected') => {
+    async (linkId: string, status: 'active' | 'revoked') => {
       const { error: err } = await supabase
         .from('parent_student_links')
         .update({ status })
-        .eq('id', linkId)
-
-      if (err) throw err
-      await fetchLinks()
-    },
-    [fetchLinks],
-  )
-
-  const unlinkStudent = useCallback(
-    async (linkId: string) => {
-      const { error: err } = await supabase
-        .from('parent_student_links')
-        .delete()
         .eq('id', linkId)
 
       if (err) throw err
@@ -102,7 +89,6 @@ export function useParentStudentLinks() {
     error,
     linkStudent,
     updateLinkStatus,
-    unlinkStudent,
     refetch: fetchLinks,
   }
 }

--- a/src/types/parent.ts
+++ b/src/types/parent.ts
@@ -20,7 +20,7 @@ export interface ParentStudentLink {
   id: string
   parent_id: string
   student_id: string
-  status: 'pending' | 'active' | 'approved' | 'revoked' | 'rejected'
+  status: 'pending' | 'active' | 'revoked'
   created_at: string
 }
 

--- a/supabase/functions/_shared/rate-limit.ts
+++ b/supabase/functions/_shared/rate-limit.ts
@@ -1,0 +1,42 @@
+import { json } from './response.ts'
+
+const requests = new Map<string, { count: number; resetAt: number }>()
+
+interface RateLimitOptions {
+  key: string
+  limit: number
+  windowMs: number
+  req: Request
+}
+
+export function getRateLimitKey(req: Request, userId: string): string {
+  const ip = req.headers.get('x-forwarded-for')?.split(',')[0]?.trim() ?? 'unknown'
+  return `${userId}:${ip}`
+}
+
+export function enforceRateLimit(options: RateLimitOptions): Response | null {
+  const now = Date.now()
+  const entry = requests.get(options.key)
+
+  if (!entry || now > entry.resetAt) {
+    requests.set(options.key, { count: 1, resetAt: now + options.windowMs })
+    return null
+  }
+
+  if (entry.count >= options.limit) {
+    const retryAfterSeconds = Math.max(1, Math.ceil((entry.resetAt - now) / 1000))
+    const response = json(
+      {
+        error: 'Rate limit exceeded',
+        retry_after_seconds: retryAfterSeconds,
+      },
+      429,
+      options.req,
+    )
+    response.headers.set('Retry-After', String(retryAfterSeconds))
+    return response
+  }
+
+  entry.count += 1
+  return null
+}

--- a/supabase/functions/_shared/response.ts
+++ b/supabase/functions/_shared/response.ts
@@ -1,34 +1,76 @@
 // supabase/functions/_shared/response.ts
 // Shared CORS headers and response helpers for all edge functions.
 
-export const corsHeaders: Record<string, string> = {
-  'Access-Control-Allow-Origin': '*',
-  'Access-Control-Allow-Methods': 'POST, GET, OPTIONS',
-  'Access-Control-Allow-Headers': 'Content-Type, Authorization, x-client-info, apikey',
+const configuredOrigins = (Deno.env.get('ALLOWED_ORIGINS') ?? 'http://localhost:5173')
+  .split(',')
+  .map((origin) => origin.trim())
+  .filter(Boolean)
+
+const vercelUrl = Deno.env.get('VERCEL_URL')
+if (vercelUrl) configuredOrigins.push(`https://${vercelUrl}`)
+
+const allowedOrigins = [...new Set(configuredOrigins)]
+const fallbackOrigin = allowedOrigins[0] ?? 'http://localhost:5173'
+
+export function resolveCorsOrigin(req: Request): string | null {
+  const origin = req.headers.get('origin')
+  if (!origin) return fallbackOrigin
+  return allowedOrigins.includes(origin) ? origin : null
 }
 
-/** Return a JSON response with CORS headers. */
-export function json(data: unknown, status = 200): Response {
-  return new Response(JSON.stringify(data), {
-    status,
+export const corsHeaders: Record<string, string> = {
+  'Access-Control-Allow-Origin': fallbackOrigin,
+  'Access-Control-Allow-Methods': 'POST, GET, OPTIONS',
+  'Access-Control-Allow-Headers': 'Content-Type, Authorization, x-client-info, apikey',
+  Vary: 'Origin',
+}
+
+export function corsHeadersFor(req: Request): Record<string, string> {
+  const origin = resolveCorsOrigin(req)
+  return {
+    ...corsHeaders,
+    ...(origin ? { 'Access-Control-Allow-Origin': origin } : {}),
+  }
+}
+
+export function rejectDisallowedOrigin(req: Request): Response | null {
+  const origin = req.headers.get('origin')
+  if (!origin) return null
+  if (resolveCorsOrigin(req)) return null
+  return new Response(JSON.stringify({ error: 'Origin not allowed' }), {
+    status: 403,
     headers: { ...corsHeaders, 'Content-Type': 'application/json' },
   })
 }
 
+export function preflight(req: Request): Response {
+  const blocked = rejectDisallowedOrigin(req)
+  if (blocked) return blocked
+  return new Response(null, { headers: corsHeadersFor(req) })
+}
+
+/** Return a JSON response with CORS headers. */
+export function json(data: unknown, status = 200, req?: Request): Response {
+  return new Response(JSON.stringify(data), {
+    status,
+    headers: { ...(req ? corsHeadersFor(req) : corsHeaders), 'Content-Type': 'application/json' },
+  })
+}
+
 /** Return a JSON error response with CORS headers. */
-export function error(message: string, status: number): Response {
-  return json({ error: message }, status)
+export function error(message: string, status: number, req?: Request): Response {
+  return json({ error: message }, status, req)
 }
 
 /**
  * Duck-type an unknown thrown value into an HTTP response.
  * Checks for a `.status` property to preserve structured errors.
  */
-export function handleError(err: unknown): Response {
+export function handleError(err: unknown, req?: Request): Response {
   if (err instanceof Error && 'status' in err) {
     const status = (err as { status: number }).status
-    return error(err.message, status)
+    return error(err.message, status, req)
   }
   console.error('Unhandled edge function error:', err)
-  return error('Internal server error', 500)
+  return error('Internal server error', 500, req)
 }

--- a/supabase/functions/agent-invoke/index.ts
+++ b/supabase/functions/agent-invoke/index.ts
@@ -1,15 +1,9 @@
-// supabase/functions/agent-invoke/index.ts
-// Edge Function: Invoke a RACA agent with guardrails
-//
-// Request body: { session_id, agent_id, learner_input, context }
-// Response: { content, reflective_questions, constraint_check, blocked }
-
-import { createClient } from 'https://esm.sh/@supabase/supabase-js@2'
+import { authenticate, requireRole } from '../_shared/authz.ts'
+import { enforceRateLimit, getRateLimitKey } from '../_shared/rate-limit.ts'
+import { handleError, json, preflight, rejectDisallowedOrigin } from '../_shared/response.ts'
 
 const ANTHROPIC_API_KEY = Deno.env.get('ANTHROPIC_API_KEY') ?? ''
 const AI_MODEL = Deno.env.get('RACA_AI_MODEL') ?? 'claude-sonnet-4-6'
-const SUPABASE_URL = Deno.env.get('SUPABASE_URL') ?? ''
-const SUPABASE_SERVICE_ROLE_KEY = Deno.env.get('SUPABASE_SERVICE_ROLE_KEY') ?? ''
 
 interface InvokeRequest {
   session_id: string
@@ -20,67 +14,61 @@ interface InvokeRequest {
 }
 
 Deno.serve(async (req: Request) => {
-  if (req.method === 'OPTIONS') {
-    return new Response(null, {
-      headers: {
-        'Access-Control-Allow-Origin': '*',
-        'Access-Control-Allow-Methods': 'POST, OPTIONS',
-        'Access-Control-Allow-Headers': 'Content-Type, Authorization',
-      },
-    })
-  }
+  if (req.method === 'OPTIONS') return preflight(req)
+
+  const blockedOrigin = rejectDisallowedOrigin(req)
+  if (blockedOrigin) return blockedOrigin
 
   try {
-    // Verify JWT
-    const authHeader = req.headers.get('Authorization')
-    if (!authHeader) {
-      return jsonResponse({ error: 'Missing authorization' }, 401)
-    }
+    const ctx = await authenticate(req)
+    requireRole(ctx, ['learner', 'admin'])
 
-    const supabase = createClient(SUPABASE_URL, SUPABASE_SERVICE_ROLE_KEY)
-    const token = authHeader.replace('Bearer ', '')
-    const { data: { user }, error: authError } = await supabase.auth.getUser(token)
-    if (authError || !user) {
-      return jsonResponse({ error: 'Unauthorized' }, 401)
-    }
+    const limited = enforceRateLimit({
+      key: getRateLimitKey(req, ctx.userId),
+      limit: 30,
+      windowMs: 60_000,
+      req,
+    })
+    if (limited) return limited
 
     const body: InvokeRequest = await req.json()
 
-    // Verify session belongs to user
-    const { data: session } = await supabase
+    const { data: session } = await ctx.adminClient
       .from('cognitive_sessions')
       .select('id, user_id, status')
       .eq('id', body.session_id)
-      .eq('user_id', user.id)
+      .eq('user_id', ctx.userId)
       .single()
 
     if (!session || session.status !== 'active') {
-      return jsonResponse({ error: 'Invalid or inactive session' }, 403)
+      return json({ error: 'Invalid or inactive session' }, 403, req)
     }
 
-    // Call AI provider
     const startTime = Date.now()
     const aiResponse = await callAI(body.system_prompt, body.learner_input, body.max_tokens)
     const responseTimeMs = Date.now() - startTime
 
-    // Log interaction
-    await supabase.from('raca_agent_interactions').insert({
+    await ctx.adminClient.from('raca_agent_interactions').insert({
       session_id: body.session_id,
       agent_id: body.agent_id,
-      state: 'UNKNOWN', // Client provides actual state
+      state: 'UNKNOWN',
       prompt: body.learner_input,
       response: aiResponse,
       blocked: false,
       response_time_ms: responseTimeMs,
     })
 
-    return jsonResponse({
-      content: aiResponse,
-      response_time_ms: responseTimeMs,
-    })
+    return json(
+      {
+        content: aiResponse,
+        response_time_ms: responseTimeMs,
+      },
+      200,
+      req,
+    )
   } catch (err) {
     console.error('agent-invoke error:', err)
-    return jsonResponse({ error: 'Internal server error' }, 500)
+    return handleError(err, req)
   }
 })
 
@@ -107,14 +95,4 @@ async function callAI(system: string, user: string, maxTokens: number): Promise<
 
   const data = await response.json()
   return data.content?.[0]?.text ?? ''
-}
-
-function jsonResponse(body: unknown, status = 200): Response {
-  return new Response(JSON.stringify(body), {
-    status,
-    headers: {
-      'Content-Type': 'application/json',
-      'Access-Control-Allow-Origin': '*',
-    },
-  })
 }

--- a/supabase/functions/epistemic-analyze/index.ts
+++ b/supabase/functions/epistemic-analyze/index.ts
@@ -1,12 +1,6 @@
-// supabase/functions/epistemic-analyze/index.ts
-// Edge Function: Analyze epistemic data and update cognitive profile
-//
-// POST: Analyze session artifacts and update learner profile
-
-import { createClient } from 'https://esm.sh/@supabase/supabase-js@2'
-
-const SUPABASE_URL = Deno.env.get('SUPABASE_URL') ?? ''
-const SUPABASE_SERVICE_ROLE_KEY = Deno.env.get('SUPABASE_SERVICE_ROLE_KEY') ?? ''
+import { authenticate, requireRole } from '../_shared/authz.ts'
+import { enforceRateLimit, getRateLimitKey } from '../_shared/rate-limit.ts'
+import { handleError, json, preflight, rejectDisallowedOrigin } from '../_shared/response.ts'
 
 interface AnalyzeRequest {
   user_id: string
@@ -27,39 +21,31 @@ interface AnalyzeRequest {
 }
 
 Deno.serve(async (req: Request) => {
-  if (req.method === 'OPTIONS') {
-    return new Response(null, {
-      headers: {
-        'Access-Control-Allow-Origin': '*',
-        'Access-Control-Allow-Methods': 'POST, OPTIONS',
-        'Access-Control-Allow-Headers': 'Content-Type, Authorization',
-      },
-    })
-  }
+  if (req.method === 'OPTIONS') return preflight(req)
 
-  const authHeader = req.headers.get('Authorization')
-  if (!authHeader) {
-    return jsonResponse({ error: 'Missing authorization' }, 401)
-  }
-
-  const supabase = createClient(SUPABASE_URL, SUPABASE_SERVICE_ROLE_KEY)
-  const token = authHeader.replace('Bearer ', '')
-  const { data: { user }, error: authError } = await supabase.auth.getUser(token)
-  if (authError || !user) {
-    return jsonResponse({ error: 'Unauthorized' }, 401)
-  }
+  const blockedOrigin = rejectDisallowedOrigin(req)
+  if (blockedOrigin) return blockedOrigin
 
   try {
+    const ctx = await authenticate(req)
+    requireRole(ctx, ['learner', 'admin'])
+
+    const limited = enforceRateLimit({
+      key: getRateLimitKey(req, ctx.userId),
+      limit: 20,
+      windowMs: 60_000,
+      req,
+    })
+    if (limited) return limited
+
     const body: AnalyzeRequest = await req.json()
 
-    // Fetch existing profile
-    const { data: existing } = await supabase
+    const { data: existing } = await ctx.adminClient
       .from('epistemic_profiles')
       .select('*')
-      .eq('user_id', user.id)
+      .eq('user_id', ctx.userId)
       .single()
 
-    // Compute updated profile metrics
     const sessionCount = (existing?.session_count ?? 0) + 1
     const revisionCount = body.artifacts.filter((a) => a.kind === 'revision').length
     const reflections = body.artifacts.filter(
@@ -68,7 +54,6 @@ Deno.serve(async (req: Request) => {
     const defenses = body.artifacts.filter((a) => a.kind === 'defense_response')
     const frames = body.artifacts.filter((a) => a.kind === 'position_frame')
 
-    // Running averages
     const prevCount = existing?.session_count ?? 0
     const runAvg = (prev: number, current: number) =>
       prevCount > 0 ? (prev * prevCount + current) / sessionCount : current
@@ -86,7 +71,7 @@ Deno.serve(async (req: Request) => {
       : 0
 
     const profile = {
-      user_id: user.id,
+      user_id: ctx.userId,
       session_count: sessionCount,
       revision_frequency: runAvg(existing?.revision_frequency ?? 0, revisionCount > 0 ? 1 : 0),
       reflection_depth_avg: runAvg(existing?.reflection_depth_avg ?? 0, reflectionDepth),
@@ -106,25 +91,15 @@ Deno.serve(async (req: Request) => {
       updated_at: new Date().toISOString(),
     }
 
-    const { error } = await supabase
+    const { error } = await ctx.adminClient
       .from('epistemic_profiles')
       .upsert(profile, { onConflict: 'user_id' })
 
-    if (error) return jsonResponse({ error: error.message }, 500)
+    if (error) return json({ error: error.message }, 500, req)
 
-    return jsonResponse({ profile })
+    return json({ profile }, 200, req)
   } catch (err) {
     console.error('epistemic-analyze error:', err)
-    return jsonResponse({ error: 'Internal server error' }, 500)
+    return handleError(err, req)
   }
 })
-
-function jsonResponse(body: unknown, status = 200): Response {
-  return new Response(JSON.stringify(body), {
-    status,
-    headers: {
-      'Content-Type': 'application/json',
-      'Access-Control-Allow-Origin': '*',
-    },
-  })
-}

--- a/supabase/functions/rate-limit-middleware/index.ts
+++ b/supabase/functions/rate-limit-middleware/index.ts
@@ -4,11 +4,7 @@
 // Returns 429 when rate limited, { allowed: true } when allowed.
 // Uses in-memory tracking (resets on cold start — acceptable for MVP).
 
-const corsHeaders = {
-  'Access-Control-Allow-Origin': '*',
-  'Access-Control-Allow-Methods': 'GET, POST, OPTIONS',
-  'Access-Control-Allow-Headers': 'Content-Type, Authorization',
-}
+import { corsHeadersFor, preflight } from '../_shared/response.ts'
 
 // Simple in-memory rate limiter
 const requests = new Map<string, { count: number; resetAt: number }>()
@@ -27,7 +23,7 @@ function isRateLimited(ip: string, limit: number, windowMs: number): boolean {
 
 Deno.serve(async (req: Request) => {
   if (req.method === 'OPTIONS') {
-    return new Response('ok', { headers: corsHeaders })
+    return preflight(req)
   }
 
   const ip = req.headers.get('x-forwarded-for') ?? 'unknown'
@@ -39,7 +35,7 @@ Deno.serve(async (req: Request) => {
     return new Response(JSON.stringify({ error: 'Rate limit exceeded' }), {
       status: 429,
       headers: {
-        ...corsHeaders,
+        ...corsHeadersFor(req),
         'Content-Type': 'application/json',
         'Retry-After': '60',
       },
@@ -47,6 +43,6 @@ Deno.serve(async (req: Request) => {
   }
 
   return new Response(JSON.stringify({ allowed: true }), {
-    headers: { ...corsHeaders, 'Content-Type': 'application/json' },
+    headers: { ...corsHeadersFor(req), 'Content-Type': 'application/json' },
   })
 })

--- a/supabase/functions/session-sync/index.ts
+++ b/supabase/functions/session-sync/index.ts
@@ -1,63 +1,50 @@
-// supabase/functions/session-sync/index.ts
-// Edge Function: Sync session state between client and database
-//
-// POST: Upsert session state
-// GET:  Retrieve session state by session_id
-
-import { createClient } from 'https://esm.sh/@supabase/supabase-js@2'
-
-const SUPABASE_URL = Deno.env.get('SUPABASE_URL') ?? ''
-const SUPABASE_SERVICE_ROLE_KEY = Deno.env.get('SUPABASE_SERVICE_ROLE_KEY') ?? ''
+import { authenticate, requireRole } from '../_shared/authz.ts'
+import { enforceRateLimit, getRateLimitKey } from '../_shared/rate-limit.ts'
+import { handleError, json, preflight, rejectDisallowedOrigin } from '../_shared/response.ts'
 
 Deno.serve(async (req: Request) => {
-  if (req.method === 'OPTIONS') {
-    return new Response(null, {
-      headers: {
-        'Access-Control-Allow-Origin': '*',
-        'Access-Control-Allow-Methods': 'GET, POST, OPTIONS',
-        'Access-Control-Allow-Headers': 'Content-Type, Authorization',
-      },
-    })
-  }
+  if (req.method === 'OPTIONS') return preflight(req)
 
-  const authHeader = req.headers.get('Authorization')
-  if (!authHeader) {
-    return jsonResponse({ error: 'Missing authorization' }, 401)
-  }
-
-  const supabase = createClient(SUPABASE_URL, SUPABASE_SERVICE_ROLE_KEY)
-  const token = authHeader.replace('Bearer ', '')
-  const { data: { user }, error: authError } = await supabase.auth.getUser(token)
-  if (authError || !user) {
-    return jsonResponse({ error: 'Unauthorized' }, 401)
-  }
+  const blockedOrigin = rejectDisallowedOrigin(req)
+  if (blockedOrigin) return blockedOrigin
 
   try {
+    const ctx = await authenticate(req)
+    requireRole(ctx, ['learner', 'admin'])
+
+    const limited = enforceRateLimit({
+      key: getRateLimitKey(req, ctx.userId),
+      limit: 60,
+      windowMs: 60_000,
+      req,
+    })
+    if (limited) return limited
+
     if (req.method === 'GET') {
       const url = new URL(req.url)
       const sessionId = url.searchParams.get('session_id')
       if (!sessionId) {
-        return jsonResponse({ error: 'session_id required' }, 400)
+        return json({ error: 'session_id required' }, 400, req)
       }
 
-      const { data, error } = await supabase
+      const { data, error } = await ctx.adminClient
         .from('cognitive_sessions')
         .select('*')
         .eq('id', sessionId)
-        .eq('user_id', user.id)
+        .eq('user_id', ctx.userId)
         .single()
 
-      if (error) return jsonResponse({ error: error.message }, 404)
-      return jsonResponse({ session: data })
+      if (error) return json({ error: error.message }, 404, req)
+      return json({ session: data }, 200, req)
     }
 
     if (req.method === 'POST') {
       const body = await req.json()
 
-      const { error } = await supabase.from('cognitive_sessions').upsert(
+      const { error } = await ctx.adminClient.from('cognitive_sessions').upsert(
         {
           id: body.session_id,
-          user_id: user.id,
+          user_id: ctx.userId,
           lesson_id: body.lesson_id,
           course_id: body.course_id,
           status: body.status,
@@ -69,23 +56,13 @@ Deno.serve(async (req: Request) => {
         { onConflict: 'id' },
       )
 
-      if (error) return jsonResponse({ error: error.message }, 500)
-      return jsonResponse({ success: true })
+      if (error) return json({ error: error.message }, 500, req)
+      return json({ success: true }, 200, req)
     }
 
-    return jsonResponse({ error: 'Method not allowed' }, 405)
+    return json({ error: 'Method not allowed' }, 405, req)
   } catch (err) {
     console.error('session-sync error:', err)
-    return jsonResponse({ error: 'Internal server error' }, 500)
+    return handleError(err, req)
   }
 })
-
-function jsonResponse(body: unknown, status = 200): Response {
-  return new Response(JSON.stringify(body), {
-    status,
-    headers: {
-      'Content-Type': 'application/json',
-      'Access-Control-Allow-Origin': '*',
-    },
-  })
-}

--- a/supabase/migrations/032_rls_hardening_and_parent_messages.sql
+++ b/supabase/migrations/032_rls_hardening_and_parent_messages.sql
@@ -1,0 +1,139 @@
+-- Migration 032: RLS hardening + parent messaging
+
+-- ISSUE 1: adaptive_learning_state requires INSERT for upsert-first-write.
+DROP POLICY IF EXISTS "Users insert own adaptive state" ON public.adaptive_learning_state;
+CREATE POLICY "Users insert own adaptive state" ON public.adaptive_learning_state
+  FOR INSERT WITH CHECK (auth.uid() = user_id);
+
+-- ISSUE 2 + ISSUE 8: Complete parent_student_links lifecycle and normalize statuses.
+ALTER TABLE public.parent_student_links
+  DROP CONSTRAINT IF EXISTS parent_student_links_status_check;
+
+ALTER TABLE public.parent_student_links
+  ADD CONSTRAINT parent_student_links_status_check
+  CHECK (status IN ('pending', 'active', 'revoked'));
+
+DROP POLICY IF EXISTS "Parents update own links" ON public.parent_student_links;
+CREATE POLICY "Parents update own links" ON public.parent_student_links
+  FOR UPDATE
+  USING (auth.uid() = parent_id)
+  WITH CHECK (
+    auth.uid() = parent_id
+    AND status IN ('pending', 'active', 'revoked')
+  );
+
+DROP POLICY IF EXISTS "Students respond to pending links" ON public.parent_student_links;
+CREATE POLICY "Students respond to pending links" ON public.parent_student_links
+  FOR UPDATE
+  USING (auth.uid() = student_id AND status = 'pending')
+  WITH CHECK (auth.uid() = student_id AND status IN ('active', 'revoked'));
+
+DROP POLICY IF EXISTS "Admins manage all links" ON public.parent_student_links;
+CREATE POLICY "Admins manage all links" ON public.parent_student_links
+  FOR UPDATE
+  USING (
+    EXISTS (
+      SELECT 1 FROM public.profiles p
+      WHERE p.user_id = auth.uid() AND p.role = 'admin'
+    )
+  )
+  WITH CHECK (
+    EXISTS (
+      SELECT 1 FROM public.profiles p
+      WHERE p.user_id = auth.uid() AND p.role = 'admin'
+    )
+  );
+
+DROP POLICY IF EXISTS "Admins delete links" ON public.parent_student_links;
+CREATE POLICY "Admins delete links" ON public.parent_student_links
+  FOR DELETE
+  USING (
+    EXISTS (
+      SELECT 1 FROM public.profiles p
+      WHERE p.user_id = auth.uid() AND p.role = 'admin'
+    )
+  );
+
+-- ISSUE 3: class_enrollments needs DELETE for educator class ownership.
+DROP POLICY IF EXISTS "Educators delete class enrollments" ON public.class_enrollments;
+CREATE POLICY "Educators delete class enrollments" ON public.class_enrollments
+  FOR DELETE USING (
+    EXISTS (
+      SELECT 1 FROM public.classes c
+      WHERE c.id = class_enrollments.class_id
+      AND c.educator_id = auth.uid()
+    )
+  );
+
+-- ISSUE 4: Parent <-> educator direct messaging table with strict relationship checks.
+CREATE TABLE IF NOT EXISTS public.messages (
+  id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  sender_id uuid NOT NULL REFERENCES public.profiles(user_id) ON DELETE CASCADE,
+  recipient_id uuid NOT NULL REFERENCES public.profiles(user_id) ON DELETE CASCADE,
+  body text NOT NULL,
+  created_at timestamptz NOT NULL DEFAULT now(),
+  CHECK (sender_id <> recipient_id)
+);
+
+CREATE INDEX IF NOT EXISTS idx_messages_participants_created
+  ON public.messages (sender_id, recipient_id, created_at DESC);
+
+ALTER TABLE public.messages ENABLE ROW LEVEL SECURITY;
+
+DROP POLICY IF EXISTS "Participants read messages" ON public.messages;
+CREATE POLICY "Participants read messages" ON public.messages
+  FOR SELECT USING (auth.uid() = sender_id OR auth.uid() = recipient_id);
+
+DROP POLICY IF EXISTS "Parents message linked educators" ON public.messages;
+CREATE POLICY "Parents message linked educators" ON public.messages
+  FOR INSERT WITH CHECK (
+    auth.uid() = sender_id
+    AND EXISTS (
+      SELECT 1
+      FROM public.profiles parent_profile
+      WHERE parent_profile.user_id = auth.uid()
+      AND parent_profile.role = 'parent'
+    )
+    AND EXISTS (
+      SELECT 1
+      FROM public.profiles educator_profile
+      WHERE educator_profile.user_id = recipient_id
+      AND educator_profile.role = 'educator'
+    )
+    AND EXISTS (
+      SELECT 1
+      FROM public.parent_student_links psl
+      JOIN public.class_enrollments ce ON ce.student_id = psl.student_id
+      JOIN public.classes c ON c.id = ce.class_id
+      WHERE psl.parent_id = auth.uid()
+      AND psl.status = 'active'
+      AND c.educator_id = recipient_id
+    )
+  );
+
+DROP POLICY IF EXISTS "Educators message linked parents" ON public.messages;
+CREATE POLICY "Educators message linked parents" ON public.messages
+  FOR INSERT WITH CHECK (
+    auth.uid() = sender_id
+    AND EXISTS (
+      SELECT 1
+      FROM public.profiles educator_profile
+      WHERE educator_profile.user_id = auth.uid()
+      AND educator_profile.role = 'educator'
+    )
+    AND EXISTS (
+      SELECT 1
+      FROM public.profiles parent_profile
+      WHERE parent_profile.user_id = recipient_id
+      AND parent_profile.role = 'parent'
+    )
+    AND EXISTS (
+      SELECT 1
+      FROM public.parent_student_links psl
+      JOIN public.class_enrollments ce ON ce.student_id = psl.student_id
+      JOIN public.classes c ON c.id = ce.class_id
+      WHERE psl.parent_id = recipient_id
+      AND psl.status = 'active'
+      AND c.educator_id = auth.uid()
+    )
+  );


### PR DESCRIPTION
### Motivation
- Close critical Supabase RLS gaps so client flows (upsert, parent↔student links, educator roster management) work without exposing cross-user writes.  
- Replace ad-hoc messaging in `notifications` with a relationship-aware `messages` table to prevent parent spam and enforce parent↔educator consent.  
- Harden AI Edge Functions by removing wildcard CORS, centralizing auth/response handling, and adding rate-limiting to prevent abuse.  

### Description
- Added migration `supabase/migrations/032_rls_hardening_and_parent_messages.sql` that: creates an owner-scoped `FOR INSERT` policy for `adaptive_learning_state`, normalizes `parent_student_links` statuses to `pending|active|revoked`, adds parent/student/admin `FOR UPDATE` policies plus admin-only `FOR DELETE`, adds educator-scoped `FOR DELETE` on `class_enrollments`, and creates a new `messages` table with participant-only `SELECT` and relationship-aware `INSERT` policies.  
- Refactored front-end parent messaging to use `messages` (query, realtime subscription, and `insert` now use `sender_id`/`recipient_id`) and updated link lifecycle UI/hook/types to the soft-state model (removed client-side `delete` flow and `approved|rejected` variants).  
- Standardized edge functions (`agent-invoke`, `session-sync`, `epistemic-analyze`) to use `supabase/functions/_shared/authz.ts` and `supabase/functions/_shared/response.ts`, removed wildcard CORS, introduced `resolveCorsOrigin`/`corsHeadersFor`/`preflight` helpers, and added a reusable in-memory rate limiter in `supabase/functions/_shared/rate-limit.ts` with per-endpoint limits (`agent-invoke`: 30/min, `session-sync`: 60/min, `epistemic-analyze`: 20/min).  
- Updated `supabase/functions/rate-limit-middleware` to use the shared response/CORS helpers and standardized error/429 shapes with `Retry-After`.  

### Testing
- Ran `npm run typecheck` which failed due to pre-existing TypeScript errors in `src/components/auth/ProtectedRoute.tsx` that are unrelated to these changes.  
- Ran `npx eslint` on modified frontend files which completed and reported only repository ignore warnings (no new lint errors introduced).  
- Verified removal of wildcard CORS in edge functions by searching for `Access-Control-Allow-Origin: '*'` under `supabase/functions`, which returned no remaining wildcard usages.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a654cc2010832a92f17ba807380141)