### PR TITLE
Catch email rate limit errors by code and message

### DIFF
--- a/src/pages/CheckEmailPage.tsx
+++ b/src/pages/CheckEmailPage.tsx
@@ -60,7 +60,12 @@ export function CheckEmailPage() {
       setResendSuccess(true)
     } catch (err) {
       const authErr = err as AuthError
-      if (authErr?.status === 429) {
+      const isRateLimit =
+        authErr?.status === 429 ||
+        authErr?.code === 'over_email_send_rate_limit' ||
+        authErr?.code === 'over_request_rate_limit' ||
+        (err instanceof Error && err.message.toLowerCase().includes('rate limit'))
+      if (isRateLimit) {
         setResendError('Too many requests. Please wait a minute before trying again.')
       } else {
         setResendError(err instanceof Error ? err.message : 'Failed to resend. Please try again.')

--- a/src/pages/SignUpPage.tsx
+++ b/src/pages/SignUpPage.tsx
@@ -43,7 +43,12 @@ export function SignUpPage() {
       navigate(session ? '/dashboard' : '/check-email')
     } catch (err) {
       const authErr = err as AuthError
-      if (authErr?.status === 429) {
+      const isRateLimit =
+        authErr?.status === 429 ||
+        authErr?.code === 'over_email_send_rate_limit' ||
+        authErr?.code === 'over_request_rate_limit' ||
+        (err instanceof Error && err.message.toLowerCase().includes('rate limit'))
+      if (isRateLimit) {
         setError('Too many sign-up attempts. Please wait a few minutes before trying again.')
       } else {
         setError(err instanceof Error ? err.message : 'Sign up failed')


### PR DESCRIPTION
## Summary

The previous 429 fix only checked `authErr.status === 429`, but Supabase's `over_email_send_rate_limit` error can come through with a different status code in some SDK versions. Now matching by all three:

- `status === 429`
- `code === 'over_email_send_rate_limit'`
- `code === 'over_request_rate_limit'`
- `message.toLowerCase().includes('rate limit')` (catch-all)

Applies to both the sign-up form and the check-email resend form.

## Test plan

- [ ] Hit Supabase email rate limit on sign-up → see "Too many sign-up attempts. Please wait a few minutes…"
- [ ] Hit rate limit on resend → see "Too many requests. Please wait a minute…"

🤖 Generated with [Claude Code](https://claude.com/claude-code)